### PR TITLE
Add archive type keyword

### DIFF
--- a/upt_macports/templates/base.Portfile
+++ b/upt_macports/templates/base.Portfile
@@ -16,7 +16,13 @@ platforms           darwin
 # supported_archs     noarch
 
 {% block dist_info %}
-{% endblock %}
+{% endblock -%}
+
+{% if pkg.archive_type == 'unknown' -%}
+# Detection of archive type failed
+{% elif pkg.archive_type != 'gz' %}
+{{ "use_%-15s yes"|format(pkg.archive_type) }}
+{% endif %}
 
 licenses            {{ pkg.licenses }}
 

--- a/upt_macports/tests/test_macports_package.py
+++ b/upt_macports/tests/test_macports_package.py
@@ -32,5 +32,26 @@ class TestMacPortsPackageLicenses(unittest.TestCase):
         self.assertEqual(self.package.licenses, expected)
 
 
+class TestMacPortsPackageArchiveType(unittest.TestCase):
+    def setUp(self):
+        self.package = MacPortsPackage()
+        self.package.upt_pkg = upt.Package('foo', '42')
+
+    def test_no_archive(self):
+        self.package.upt_pkg.archives = []
+        expected = 'unknown'
+        self.assertEqual(self.package.archive_type, expected)
+
+    def test_known_archive(self):
+        self.package.upt_pkg.archives = [upt.Archive("url.co/dir/file.tar.gz")]
+        expected = 'gz'
+        self.assertEqual(self.package.archive_type, expected)
+
+    def test_unknown_archive(self):
+        self.package.upt_pkg.archives = [upt.Archive("url.co/dir/file.rar")]
+        expected = 'unknown'
+        self.assertEqual(self.package.archive_type, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -51,6 +51,26 @@ class MacPortsPackage(object):
     def test_depends(self):
         return self._depends('test')
 
+    @property
+    def archive_type(self):
+        archive_keyword = {
+            'gz': 'gz',
+            '7z': '7z',
+            'bz2': 'bzip2',
+            'lzma': 'lzma',
+            'tar': 'tar',
+            'zip': 'zip',
+            'xz': 'xz'
+        }
+        try:
+            archive_name = self.upt_pkg.get_archive().filename
+            archive_type = archive_name.split('.')[-1]
+            return archive_keyword.get(archive_type, 'unknown')
+
+        except upt.ArchiveUnavailable:
+            self.logger.error('Could not determine the type of the source archive') # noqa
+            return 'unknown'
+
 
 class MacPortsPythonPackage(MacPortsPackage):
     template = 'python.Portfile'


### PR DESCRIPTION
This addresses Issue #3 

Since upt is setting archive_type to targz for all sdist, so instead of using that extracting from URL seems better.
@Steap Should this feature be directly implemented in upt itself or is this fine?

Once this is merged I will push the changes for #4 

