### PR TITLE
Update license conversion

### DIFF
--- a/upt_macports/tests/test_macports_package.py
+++ b/upt_macports/tests/test_macports_package.py
@@ -10,7 +10,7 @@ class TestMacPortsPackageLicenses(unittest.TestCase):
 
     def test_no_licenses(self):
         self.package.upt_pkg.licenses = []
-        expected = ''
+        expected = 'unknown'
         self.assertEqual(self.package.licenses, expected)
 
     def test_one_license(self):

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -34,7 +34,7 @@ class MacPortsPackage(object):
             spdx2macports = json.loads(f.read())
 
         return ' '.join([spdx2macports.get(license.spdx_identifier, 'unknown')
-                        for license in self.upt_pkg.licenses])
+                        for license in self.upt_pkg.licenses]) or 'unknown'
 
     def _depends(self, phase):
         return self.upt_pkg.requirements.get(phase, [])


### PR DESCRIPTION
Return unknown if no license found and test for the same

Fixes #14