### PR TITLE
Change python naming convention

### DIFF
--- a/upt_macports/templates/python.Portfile
+++ b/upt_macports/templates/python.Portfile
@@ -5,6 +5,9 @@ PortGroup           python 1.0
 {% endblock %}
 {% block nameversion %}
 name                {{ pkg._pkgname() }}
+{% if pkg._python_root_name() %}
+python.rootname     {{ pkg._python_root_name() }}
+{% endif %}
 version             {{ pkg.upt_pkg.version }}
 revision            0
 {% endblock %}

--- a/upt_macports/tests/test_python_package.py
+++ b/upt_macports/tests/test_python_package.py
@@ -11,7 +11,7 @@ class TestMacPortsPythonPackage(unittest.TestCase):
         self.package.upt_pkg = upt.Package('test-pkg', '13.37')
 
     def test_pkgname(self):
-        expected = ['py-foo', 'py-py-foo', 'py-pyfoo', 'py-pyFoo']
+        expected = ['py-foo', 'py-py-foo', 'py-pyfoo', 'py-pyfoo']
         names = ['foo', 'py-foo', 'pyfoo', 'pyFoo']
         for (name, expected_name) in zip(names, expected):
             self.package.upt_pkg = upt.Package(name, '13.37')

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -97,7 +97,13 @@ class MacPortsPythonPackage(MacPortsPackage):
 
     @staticmethod
     def _normalized_macports_name(name):
+        name = name.lower()
         return f'py-{name}'
+
+    def _python_root_name(self):
+        pypi_name = self.upt_pkg.get_archive().filename.split('-'+self.upt_pkg.version)[0] # noqa
+        if pypi_name != self.upt_pkg.name.lower():
+            return pypi_name
 
 
 class MacPortsNpmPackage(MacPortsPackage):


### PR DESCRIPTION
python.rootname is set if there's capitalization but this check is performed on the name supplied by the user and not on the actual name.

For example for `WTForms` and `wtforms` file is generated but one with the `rootname` field and one without which should not be usually there.
For solving this `upt-pypi` should give the actual package name instead of the name supplied by the user.