### PR TITLE
Recursive Packaging

### DIFF
--- a/upt_macports/tests/test_macports_backend.py
+++ b/upt_macports/tests/test_macports_backend.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 import upt
 from upt_macports.upt_macports import MacPortsBackend
 
@@ -12,6 +13,40 @@ class TestMacPortsBackend(unittest.TestCase):
         upt_pkg.frontend = 'invalid frontend'
         with self.assertRaises(upt.UnhandledFrontendError):
             self.macports_backend.create_package(upt_pkg)
+
+
+class TestMacPortsPackageExist(unittest.TestCase):
+    def setUp(self):
+        self.macports_backend = MacPortsBackend()
+        self.macports_backend.upt_pkg = upt.Package('foo', '42')
+        self.macports_backend.frontend = 'pypi'
+
+    @mock.patch('subprocess.getoutput')
+    def test_port_found(self, mock_sub):
+        expected = ['0.123']
+        mock_sub.return_value = 'version: 0.123'
+        self.assertEqual(
+            self.macports_backend.package_versions('foo'), expected)
+
+    @mock.patch('subprocess.getoutput')
+    def test_port_not_found(self, mock_sub):
+        expected = []
+        mock_sub.return_value = 'Error: fake-error'
+        self.assertEqual(
+            self.macports_backend.package_versions('foo'), expected)
+
+    @mock.patch('subprocess.getoutput')
+    def test_port_outdated(self, mock_sub):
+        expected = ['0.123']
+        mock_sub.return_value = 'Warning: fake-warning \nversion: 0.123'
+        self.assertEqual(
+            self.macports_backend.package_versions('foo'), expected)
+
+    @mock.patch('subprocess.getoutput')
+    def test_port_error(self, mock_sub):
+        mock_sub.return_value = 'bash: port: command not found'
+        with self.assertRaises(SystemExit):
+            self.macports_backend.package_versions('foo')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is by no means complete, but wanted to share and get input on whether is it right and what else can we do.

For this to work changes required on `upt` side will be this:
```
packages = list(args.package)
i = 0
while i < len(packages):
      try:
           upt_pkg = None
           upt.log.logger_set_formatter(logger, 'Frontend')
           upt_pkg = frontend.parse(packages[i])
           upt_pkg.frontend = args.frontend
           upt.log.logger_set_formatter(logger, 'Backend')
           upt_pkg.packages = list(packages)
           upt_pkg = backend.create_package(upt_pkg, output=args.output)
           packages = list(upt_pkg.packages)
           i += 1
```

So currently as you can see, the code doesn't check MacPorts Tree and neither ask the user.
I tested this out for `upt-cpan` and it generated this list:

```
['upt-cpan', 'requests', 'upt', 'requests-mock', 'chardet', 'idna', 
'urllib3', 'certifi', 'spdx-lookup', 'six', 'fixtures', 'mock', 
'purl', 'pytest', 'sphinx', 'testrepository', 'testtools', 'hypothesis',
 'pbr', 'pytest-cov', 'py', 'packaging', 'attrs', 'atomicwrites', 'pluggy', 
 'importlib-metadata', 'wcwidth', 'argcomplete', 'nose', 'sphinxcontrib-applehelp', 
 'sphinxcontrib-devhelp', 'sphinxcontrib-jsmath', 'sphinxcontrib-htmlhelp', 
 'sphinxcontrib-serializinghtml', 'sphinxcontrib-qthelp', 'Jinja2', 'Pygments', 
 'docutils', 'snowballstemmer', 'babel', 'alabaster', 'imagesize', 'setuptools', 
 'html5lib', 'flake8', 'flake8-import-order', 'mypy', 'docutils-stubs', 'extras', 
 'python-mimeparse', 'traceback2', 'unittest2', 'coverage', 'fields', 'hunter', 
 'process-tests', 'virtualenv', 'pyparsing', 'pympler', 'zope.interface', 'zipp', 
 'pexpect', 'wheel', 'MarkupSafe', 'pytz', 'webencodings', 'entrypoints', 'pyflakes', 
 'pycodestyle', 'mccabe', 'typed-ast', 'mypy-extensions', 'linecache2', 'contextlib2', 
 'argparse', 'colorama', 'pytest-timeout', 'pytest-xdist', 'pytest-localserver', 
 'pypiserver', 'zope.event', 'pathlib2', 'ptyprocess', 'execnet', 'pytest-forked', 
 'filelock', 'zope.testrunner', 'apipkg', 'zope.exceptions', 'zope.testing']
```

Which as you can see is very big and my guess is not required for just `upt-cpan`.
If we just take the run dependencies then the output is similar to what pypi would install, which is:

`['upt-cpan', 'requests', 'upt', 'chardet', 'idna', 'urllib3', 'certifi', 'spdx-lookup']`

So if the way I am doing it right now is fine then next thing would be to add MacPorts tree check which can be done directly by "guessing" the dependency name
and a get request like for upt to this url
`https://raw.githubusercontent.com/macports/macports-ports/master/python/py-upt/Portfile`

Is there any better way to search github for package name in macports tree so that we don't have to "guess" the path and/or can we directly get the version of the package from MacPorts somehow.

and then comes version extraction and decision that whether a Portfile should be generated or not.

In this I am not sure if we should do this fully automatically, here we can keep user-input.

