### PR TITLE
Template Cleanup

### DIFF
--- a/upt_macports/templates/base.Portfile
+++ b/upt_macports/templates/base.Portfile
@@ -1,3 +1,12 @@
+{% macro depends(kind, deps) %}
+{% if deps %}
+depends_{{ kind }}-append \
+  {% for dep in deps | unique(attribute='name') | sort(attribute='name') %}
+                    port:{{ dep|reqformat }} {%- if not loop.last %} \
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% endmacro %}
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
@@ -28,17 +37,12 @@ description         {{ pkg.upt_pkg.summary|trim|replace('\n',' \\\n')|indent(20,
 long_description    ${description}
 
 {% block dist_info %}
-{% endblock -%}
-
-{% if pkg.archive_type == 'unknown' and pkg.upt_pkg.frontend != 'rubygems' -%}
-# Detection of archive type failed
-{% elif pkg.archive_type != 'gz' and pkg.upt_pkg.frontend != 'rubygems' %}
-{{ "use_%-15s yes"|format(pkg.archive_type) }}
-{% endif %}
-
+{% endblock %}
 checksums           sha256  {{ pkg.upt_pkg.archives[0].sha256 }} \
                     rmd160  {{ pkg.upt_pkg.archives[0].rmd160 }} \
                     size    {{ pkg.upt_pkg.archives[0].size }}
-
 {% block versions %}
+{% endblock -%}
+
+{% block dependencies %}
 {% endblock %}

--- a/upt_macports/templates/perl.Portfile
+++ b/upt_macports/templates/perl.Portfile
@@ -9,36 +9,42 @@ perl5.setup         {{ pkg._pkgname() }} {{ pkg.upt_pkg.version }}{{ pkg._cpandi
 revision            0
 {% endblock %}
 
-{% block versions %}
-{%- if pkg.upt_pkg.requirements.run or pkg.upt_pkg.requirements.test or pkg.upt_pkg.requirements.build or pkg.upt_pkg.requirements.config %}
-if {${perl5.major} != ""} {
-    {%- if pkg.upt_pkg.requirements.config or pkg.upt_pkg.requirements.build %}
+{% block dist_info %}
+{% if pkg.archive_type not in ['gz', 'unknown'] -%} {{ "use_%-15s yes"|format(pkg.archive_type) }}
 
-    depends_build-append \
-                    {% for i in (pkg.upt_pkg.requirements.build + pkg.upt_pkg.requirements.config)|sort(attribute='name')|unique(attribute='name') %}
-                    port:p${perl5.major}-{{i.name|replace('::','-')|lower}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
-    {% endif %}
-
-    {% if pkg.upt_pkg.requirements.run %}
-
-    depends_lib-append \
-                    {% for i in pkg.upt_pkg.requirements.run|sort(attribute='name') %}
-                    port:p${perl5.major}-{{i.name|replace('::','-')|lower}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
-    {% endif %}
-
-    {% if pkg.upt_pkg.requirements.test %}
-
-    depends_test-append \
-                    {% for i in pkg.upt_pkg.requirements.test|sort(attribute='name') %}
-                    port:p${perl5.major}-{{i.name|replace('::','-')|lower}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
-    {% endif %}
-
-}
-{% endif %}
+{% endif -%}
 {% endblock %}
+
+{% block dependencies %}
+{%- if pkg.upt_pkg.requirements.run or pkg.upt_pkg.requirements.test or pkg.upt_pkg.requirements.build or pkg.upt_pkg.requirements.config %}
+
+if {${perl5.major} != ""} {
+    {% if pkg.upt_pkg.requirements.config and pkg.upt_pkg.requirements.build %}
+    {{ depends('build', pkg.upt_pkg.requirements.build + pkg.upt_pkg.requirements.config) -}}
+    {% elif pkg.upt_pkg.requirements.config %}
+    {{ depends('build', pkg.upt_pkg.requirements.config) -}}
+    {% elif pkg.upt_pkg.requirements.build %}
+    {{ depends('build', pkg.upt_pkg.requirements.build) -}}
+    {% endif %}
+
+    {%- if pkg.upt_pkg.requirements.run %}
+    {%- if pkg.upt_pkg.requirements.build or pkg.upt_pkg.requirements.config %}
+
+
+    {{ depends('lib', pkg.upt_pkg.requirements.run) -}}
+    {%- else %}
+    {{ depends('lib', pkg.upt_pkg.requirements.run) -}}
+    {%- endif -%}
+    {%- endif -%}
+
+    {%- if pkg.upt_pkg.requirements.test %}
+
+
+    {{ depends('test', pkg.upt_pkg.requirements.test) -}}
+    {%- endif -%}
+
+{% raw %}
+}
+{%- endraw -%}
+{%- endif -%}
+{%- endblock -%}

--- a/upt_macports/templates/python.Portfile
+++ b/upt_macports/templates/python.Portfile
@@ -16,11 +16,20 @@ revision            0
 homepage            {{ pkg.upt_pkg.homepage }}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
+{% if pkg.archive_type not in ['gz', 'unknown'] -%} {{ "use_%-15s yes"|format(pkg.archive_type) }}
+
+{% else %}
+
+{% endif %}
 {% endblock %}
 
 {% block versions %}
+
 python.versions     37
 
+{% endblock %}
+
+{% block dependencies %}
 if {${name} ne ${subport}} {
     ## setuptools is added by default as a build-dependency since this is often the case.
     ## However, if the package installs a "console_script" or uses "entry_points", setuptools
@@ -28,26 +37,21 @@ if {${name} ne ${subport}} {
     ## file that setuptools is indeed used and that the dependency-type is correct.
     depends_build-append \
                     port:py${python.version}-setuptools
-    {%- if pkg.upt_pkg.requirements.run|length > 0 %}
+
+    {%- if pkg.upt_pkg.requirements.run %}
 
 
-    depends_lib-append \
-                    {% for i in pkg.upt_pkg.requirements.run|sort(attribute='name') %}
-                    port:py${python.version}-{{i.name}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
-    {% endif %}
-    {%- if pkg.upt_pkg.requirements.test|length > 0 %}
+    {{ depends('lib', pkg.upt_pkg.requirements.run) -}}
+    {% endif -%}
+
+    {%- if pkg.upt_pkg.requirements.test %}
 
 
-    depends_test-append \
-                    {% for i in pkg.upt_pkg.requirements.test|sort(attribute='name') %}
-                    port:py${python.version}-{{i.name}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
-    {% endif %}
+    {{ depends('test', pkg.upt_pkg.requirements.test) -}}
+    {% endif -%}
 
+    {{'
 
-    livecheck.type  none
+    livecheck.type  none'}}
 }
-{% endblock %}
+{%- endblock -%}

--- a/upt_macports/templates/ruby.Portfile
+++ b/upt_macports/templates/ruby.Portfile
@@ -9,26 +9,27 @@ ruby.setup          {{ pkg._pkgname() }} {{ pkg.upt_pkg.version }} gem {} rubyge
 revision            0
 {% endblock %}
 
-{% block versions %}
-{% if pkg.upt_pkg.requirements.run or pkg.upt_pkg.requirements.test %}
+{% block dependencies %}
+
 if {${subport} ne ${name}} {
-    {% if pkg.upt_pkg.requirements.run %}
-    depends_lib-append \
-                    {% for i in pkg.upt_pkg.requirements.run|sort(attribute='name') %}
-                    port:rb${ruby.suffix}-{{i.name}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
+    {{ depends('lib', pkg.upt_pkg.requirements.run) -}}
+
+    {%- if pkg.upt_pkg.requirements.test -%}
+    {%- if pkg.upt_pkg.requirements.run %}
+
+
+    {{ depends('test', pkg.upt_pkg.requirements.test) -}}
+    {%- else -%}
+    {{ depends('test', pkg.upt_pkg.requirements.test) -}}
+    {%- endif -%}
+    {%- endif -%}
+
+    {%- if (pkg.upt_pkg.requirements.run or pkg.upt_pkg.requirements.test) %}
+
+
+    livecheck.type  none
+    {% else -%}
+    livecheck.type  none
     {% endif %}
-
-
-    {% if pkg.upt_pkg.requirements.test %}
-    depends_test-append \
-                    {% for i in pkg.upt_pkg.requirements.test|sort(attribute='name') %}
-                    port:rb${ruby.suffix}-{{i.name}}{% if not loop.last %} \
-                    {% endif %}
-                    {% endfor %}
-    {% endif %}
-
 }
-{% endif %}
-{% endblock %}
+{%- endblock -%}

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -59,6 +59,7 @@ class MacPortsPackage(object):
             lstrip_blocks=True,
             keep_trailing_newline=True,
         )
+        env.filters['reqformat'] = self.jinja2_reqformat
         template = env.get_template(self.template)
         return template.render(pkg=self)
 
@@ -149,6 +150,9 @@ class MacPortsPythonPackage(MacPortsPackage):
         name = name.lower()
         return f'py-{name}'
 
+    def jinja2_reqformat(self, req):
+        return f'py${{python.version}}-{req.name.lower()}'
+
 
 class MacPortsNpmPackage(MacPortsPackage):
     template = 'npm.Portfile'
@@ -179,6 +183,9 @@ class MacPortsPerlPackage(MacPortsPackage):
     def _normalized_macports_folder(name):
         name = name.lower().replace('::', '-')
         return f'p5-{name}'
+
+    def jinja2_reqformat(self, req):
+        return f'p${{perl5.major}}-{self._normalized_macports_name(req.name).lower()}' # noqa
 
     def _cpandir(self):
         pkg = self.upt_pkg
@@ -221,6 +228,9 @@ class MacPortsRubyPackage(MacPortsPackage):
     def _normalized_macports_folder(name):
         name = name.lower()
         return f'rb-{name}'
+
+    def jinja2_reqformat(self, req):
+        return f'rb${{ruby.suffix}}-{req.name.lower()}'
 
 
 class MacPortsBackend(upt.Backend):


### PR DESCRIPTION
As of now I have just done for python Portfile.

It works but there are issues with spacing, as for this code we get the following output
for upt:
```
    depends_build-append \
                    port:py${python.version}-setuptools

    depends_lib-append \
                port:py${python.version}-spdx-lookup


    livecheck.type  none
```

which is right but for upt-cpan it is:

```
    depends_build-append \
                    port:py${python.version}-setuptools

    depends_lib-append \
                port:py${python.version}-requests \
                port:py${python.version}-upt
    depends_test-append \
                port:py${python.version}-requests-mock

    livecheck.type  none
```

I already tried many different combination both logically and brute forcing but none gets the expected result.
The if statement around macro call is totally unnecessary and is just there as it was a possible solution as per [this](https://stackoverflow.com/questions/39712338/python-jinja2-macro-whitespace-issues). 

I will try a bit more if this can be fixed.