### PR TITLE
Fix "missing newline (at end of file)" warning

### DIFF
--- a/upt_macports/templates/perl.Portfile
+++ b/upt_macports/templates/perl.Portfile
@@ -45,6 +45,6 @@ if {${perl5.major} != ""} {
 
 {% raw %}
 }
-{%- endraw -%}
+{% endraw -%}
 {%- endif -%}
 {%- endblock -%}

--- a/upt_macports/templates/python.Portfile
+++ b/upt_macports/templates/python.Portfile
@@ -54,4 +54,4 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none'}}
 }
-{%- endblock -%}
+{% endblock %}

--- a/upt_macports/templates/ruby.Portfile
+++ b/upt_macports/templates/ruby.Portfile
@@ -32,4 +32,4 @@ if {${subport} ne ${name}} {
     livecheck.type  none
     {% endif %}
 }
-{%- endblock -%}
+{% endblock %}


### PR DESCRIPTION
All python/perl/rubygems templates removed the newline at the end. A warning message was displayed when using ```port lint --nitpick <portname>``` not without the ```--nitpick``` flag. Nevertheless, it should be fixed and this PR does that.

[edit: force-pushed to associate this commit with my MacPorts e-maill address.]