### PR TITLE
Fix license logging and add messages to the template

### DIFF
--- a/upt_macports/tests/test_macports_package.py
+++ b/upt_macports/tests/test_macports_package.py
@@ -17,7 +17,7 @@ class TestMacPortsPackageLicenses(unittest.TestCase):
 
     def test_no_licenses(self):
         self.package.upt_pkg.licenses = []
-        expected = 'unknown'
+        expected = 'unknown  # no upstream license found'
         self.assertEqual(self.package.licenses, expected)
 
     def test_one_license(self):
@@ -27,12 +27,12 @@ class TestMacPortsPackageLicenses(unittest.TestCase):
 
     def test_unknown_license(self):
         self.package.upt_pkg.licenses = [FakeLicense]
-        expected = 'unknown # MacPorts license unknown for fake'
+        expected = 'unknown  # MacPorts license unknown for fake'
         self.assertEqual(self.package.licenses, expected)
 
     def test_bad_license(self):
         self.package.upt_pkg.licenses = [upt.licenses.UnknownLicense()]
-        expected = 'unknown'
+        expected = 'unknown  # upt failed to detect license'
         self.assertEqual(self.package.licenses, expected)
 
     def test_multiple_license(self):

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -64,21 +64,22 @@ class MacPortsPackage(object):
             spdx2macports = json.loads(f.read())
 
         if not self.upt_pkg.licenses:
-            self.logger.info('No license found')
-            return 'unknown'
+            self.logger.warning('No license found')
+            return 'unknown  # no upstream license found'
         licenses = []
         for license in self.upt_pkg.licenses:
             try:
                 if license.spdx_identifier == 'unknown':
-                    port_license = 'unknown'
-                    self.logger.warning(f'upt failed to detect license')
+                    warn = 'upt failed to detect license'
+                    port_license = f'unknown  # {warn}'
+                    self.logger.warning(warn)
                 else:
                     port_license = spdx2macports[license.spdx_identifier]
                     self.logger.info(f'Found license {port_license}')
                 licenses.append(port_license)
             except KeyError:
                 err = f'MacPorts license unknown for {license.spdx_identifier}'
-                licenses.append('unknown # ' + err)
+                licenses.append(f'unknown  # {err}')
                 self.logger.error(err)
                 self.logger.info('Please report the error at https://github.com/macports/upt-macports') # noqa
         return ' '.join(licenses)


### PR DESCRIPTION
This PR makes the changes below to the license logging and templates:

- "no license found" should be logged as warning, not as info
- add the reasons (i.e., "no upstream license found" and "upt failed to detect the license") to the template as helpful information for the maintainer to figure out why the ```license``` field was set to "uknown" by ```upt```
- use two spaces for inline comments