### PR TITLE
Remove master_sites and distname from Python template

### DIFF
--- a/upt_macports/templates/python.Portfile
+++ b/upt_macports/templates/python.Portfile
@@ -14,8 +14,6 @@ revision            0
 
 {% block dist_info %}
 homepage            {{ pkg.upt_pkg.homepage }}
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 {% if pkg.archive_type not in ['gz', 'unknown'] -%} {{ "use_%-15s yes"|format(pkg.archive_type) }}
 
 {% else %}


### PR DESCRIPTION
These fields are now set to the default values by the Python PG; see commit: https://github.com/macports/macports-ports/commit/46cbc043fc68208dbb8b7ad20e3fe9dadfd9bd12