### PR TITLE
Add homepage to Ruby template (fixes lint error)

### DIFF
--- a/upt_macports/templates/ruby.Portfile
+++ b/upt_macports/templates/ruby.Portfile
@@ -9,6 +9,15 @@ ruby.setup          {{ pkg._pkgname() }} {{ pkg.upt_pkg.version }} gem {} rubyge
 revision            0
 {% endblock %}
 
+{% block dist_info %}
+{%- if pkg.upt_pkg.homepage | lower not in ['', 'none', 'unknown'] -%}
+homepage            {{ pkg.upt_pkg.homepage }}
+{% else %}
+homepage            https://www.rubygems.org/gems/{{ pkg._pkgname() }}
+{% endif %}
+
+{% endblock %}
+
 {% block dependencies %}
 
 if {${subport} ne ${name}} {


### PR DESCRIPTION
If none specified use the default ```https://www.rubygems.org/gems/${portname}```. This should eventually go into a revamped PG, but for now put it in the template.