### PR TITLE
Set homepage in templates when needed

### DIFF
--- a/upt_macports/templates/perl.Portfile
+++ b/upt_macports/templates/perl.Portfile
@@ -10,6 +10,10 @@ revision            0
 {% endblock %}
 
 {% block dist_info %}
+{%- if pkg.homepage -%}
+homepage            {{ pkg.homepage }}
+
+{% endif %}
 {% if pkg.archive_type not in ['gz', 'unknown'] -%} {{ "use_%-15s yes"|format(pkg.archive_type) }}
 
 {% endif -%}

--- a/upt_macports/templates/python.Portfile
+++ b/upt_macports/templates/python.Portfile
@@ -13,7 +13,7 @@ revision            0
 {% endblock %}
 
 {% block dist_info %}
-homepage            {{ pkg.upt_pkg.homepage }}
+homepage            {{ pkg.homepage }}
 {% if pkg.archive_type not in ['gz', 'unknown'] -%} {{ "use_%-15s yes"|format(pkg.archive_type) }}
 
 {% else %}

--- a/upt_macports/templates/ruby.Portfile
+++ b/upt_macports/templates/ruby.Portfile
@@ -9,6 +9,11 @@ ruby.setup          {{ pkg._pkgname() }} {{ pkg.upt_pkg.version }} gem {} rubyge
 revision            0
 {% endblock %}
 
+{% block dist_info %}
+homepage            {{ pkg.homepage }}
+
+{% endblock %}
+
 {% block dependencies %}
 
 if {${subport} ne ${name}} {

--- a/upt_macports/tests/test_perl_package.py
+++ b/upt_macports/tests/test_perl_package.py
@@ -52,6 +52,26 @@ class TestMacPortsPerlPackage(unittest.TestCase):
         self.assertEqual(self.package.jinja2_reqformat(req),
                          'p${perl5.major}-require')
 
+    def test_homepage(self):
+        upt_homepages = [
+            '',
+            'unknown',
+            'https://github.com/Foo-Bar',
+            'https://metacpan.org/pod/Foo-Bar'
+        ]
+
+        excpected_homepages = [
+            None,
+            None,
+            'https://github.com/Foo-Bar',
+            None
+        ]
+
+        for (upt_homepage, expected_homepage) in zip(upt_homepages,
+                                                     excpected_homepages):
+            self.package.upt_pkg.homepage = upt_homepage
+            self.assertEqual(self.package.homepage, expected_homepage)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/upt_macports/tests/test_python_package.py
+++ b/upt_macports/tests/test_python_package.py
@@ -48,6 +48,24 @@ class TestMacPortsPythonPackage(unittest.TestCase):
         self.assertEqual(self.package.jinja2_reqformat(req),
                          'py${python.version}-require')
 
+    def test_homepage(self):
+        upt_homepages = [
+            '',
+            'unknown',
+            'https://github.com/test-pkg'
+        ]
+
+        excpected_homepages = [
+            'https://pypi.org/project/test-pkg',
+            'https://pypi.org/project/test-pkg',
+            'https://github.com/test-pkg'
+        ]
+
+        for (upt_homepage, expected_homepage) in zip(upt_homepages,
+                                                     excpected_homepages):
+            self.package.upt_pkg.homepage = upt_homepage
+            self.assertEqual(self.package.homepage, expected_homepage)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/upt_macports/tests/test_ruby_package.py
+++ b/upt_macports/tests/test_ruby_package.py
@@ -29,6 +29,24 @@ class TestMacPortsRubyPackage(unittest.TestCase):
         self.assertEqual(self.package.jinja2_reqformat(req),
                          'rb${ruby.suffix}-require')
 
+    def test_homepage(self):
+        upt_homepages = [
+            '',
+            'unknown',
+            'https://github.com/test-pkg',
+        ]
+
+        excpected_homepages = [
+            'https://rubygems.org/gems/test-pkg',
+            'https://rubygems.org/gems/test-pkg',
+            'https://github.com/test-pkg'
+        ]
+
+        for (upt_homepage, expected_homepage) in zip(upt_homepages,
+                                                     excpected_homepages):
+            self.package.upt_pkg.homepage = upt_homepage
+            self.assertEqual(self.package.homepage, expected_homepage)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -120,6 +120,10 @@ class MacPortsPackage(object):
             self.logger.error('Could not determine the type of the source archive') # noqa
             return 'unknown'
 
+    @property
+    def homepage(self):
+        return self.upt_pkg.homepage
+
     def _pkgname(self):
         return self._normalized_macports_name(self.upt_pkg.name)
 
@@ -146,6 +150,14 @@ class MacPortsPythonPackage(MacPortsPackage):
 
     def jinja2_reqformat(self, req):
         return f'py${{python.version}}-{req.name.lower()}'
+
+    @property
+    def homepage(self):
+        homepage = self.upt_pkg.homepage
+        if homepage.startswith('http'):
+            return homepage
+        else:
+            return f'https://pypi.org/project/{self.upt_pkg.name}'
 
 
 class MacPortsPerlPackage(MacPortsPackage):
@@ -189,6 +201,15 @@ class MacPortsPerlPackage(MacPortsPackage):
             self.logger.info('Using fallback location for dist file')
             return f' ../../authors/id/{fallback_dist}/'
 
+    @property
+    def homepage(self):
+        homepage = self.upt_pkg.homepage
+        portgroup_default = 'metacpan.org/pod'
+        if homepage.startswith('http') and portgroup_default not in homepage:
+            return homepage
+        else:
+            return None
+
 
 class MacPortsRubyPackage(MacPortsPackage):
     template = 'ruby.Portfile'
@@ -206,6 +227,14 @@ class MacPortsRubyPackage(MacPortsPackage):
 
     def jinja2_reqformat(self, req):
         return f'rb${{ruby.suffix}}-{req.name.lower()}'
+
+    @property
+    def homepage(self):
+        homepage = self.upt_pkg.homepage
+        if homepage.startswith('http'):
+            return homepage
+        else:
+            return f'https://rubygems.org/gems/{self.upt_pkg.name}'
 
 
 class MacPortsBackend(upt.Backend):


### PR DESCRIPTION
If upstream has set a homepage, and that one is different than what is set by the ```perl5-1.0``` PG, add it to the template. Otherwise let the PG take care of it.