### PR TITLE
Update metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright YEAR      Mojca Miklavec
+Copyright 2019      The MacPorts Project
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,11 +15,14 @@ strategy:
       imageName: 'ubuntu-16.04'
       python.version: '3.7'
     py36_macos:
-      imageName: 'macos-10.13'
+      imageName: 'macos-10.14'
       python.version: '3.6'
     py37_macos:
-      imageName: 'macos-10.13'
+      imageName: 'macos-10.14'
       python.version: '3.7'
+    py38_macos:
+      imageName: 'macos-10.14'
+      python.version: '3.8'
 
 pool:
   vmImage: $(imageName)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,15 +4,17 @@ version = 0.1
 description = MacPorts backend for upt.
 long_description = file: README.md
 long_description_content_type = text/markdown
-author = Mojca Miklavec
-author_email = mojca@macports.org
-url= https://framagit.org/upt/upt-macports
+author = The MacPorts Project
+author_email = macports-dev@lists.macports.org
+url= https://github.com/macports/upt-macports
 python_requires = >= 3.6
 classifiers =
     Development Status :: 3 - Alpha
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
 
 [options]


### PR DESCRIPTION
This PR makes the following changes:

-  add Python 3.7 and 3.8 Trove classifiers
- set ```author``` field to "The MacPorts Project" (@mojca are you okay with that?). I am not sure what e-mail address to use, suggestions are welcome.
- set ```url``` to the GitHub page 
- add Python 3.8 to the Azure pipelines for testing
- use same license text (still BSD-3) and copyright statement as for ```macports-base```