### PR TITLE
default to python 3.8

### DIFF
--- a/upt_macports/templates/python.Portfile
+++ b/upt_macports/templates/python.Portfile
@@ -23,7 +23,7 @@ homepage            {{ pkg.homepage }}
 
 {% block versions %}
 
-python.versions     37
+python.versions     38
 
 {% endblock %}
 


### PR DESCRIPTION
As suggested by @mojca in [#6436](https://github.com/macports/macports-ports/pull/6436)