### PR TITLE
Update "_python_root_name" function

### DIFF
--- a/upt_macports/tests/test_python_package.py
+++ b/upt_macports/tests/test_python_package.py
@@ -25,23 +25,12 @@ class TestMacPortsPythonPackage(unittest.TestCase):
                 self.package._normalized_macports_folder(name), expected_name)
 
     def test_py_root_name(self):
-        url_names = ['foo', 'Foo', 'Foo', 'foo']
-        pypi_names = ['foo', 'foo', 'pyFoo', 'py-Foo']
-        urls = [
-            'https://fakepypi.com/random/path/foo-13.37.tar.gz',
-            'https://fakepypi.com/random/path/Foo-13.37.tar.gz',
-            'https://fakepypi.com/random/path/Foo-13.37.tar.gz',
-            'https://fakepypi.com/random/path/foo-13.37.tar.gz'
-        ]
-        for (url_name, pypi_name, url) in zip(url_names, pypi_names, urls):
+        pypi_names = ['foo', 'Foo', 'pyFoo', 'pyfoo', 'py-Foo']
+        expected_python_rootnames = [None, 'Foo', 'pyFoo', None, 'py-Foo']
+        for (pypi_name, python_rootname) in zip(pypi_names,
+                                                expected_python_rootnames):
             self.package.upt_pkg = upt.Package(pypi_name, '13.37')
-            self.package.upt_pkg.archives = [upt.Archive(url)]
-            if url_name != pypi_name:
-                self.assertEqual(
-                    self.package._python_root_name(), url_name)
-            else:
-                self.assertEqual(
-                    self.package._python_root_name(), None)
+            self.assertEqual(self.package._python_root_name(), python_rootname)
 
     def test_jinja2_reqformat(self):
         req = upt.PackageRequirement('Require')

--- a/upt_macports/upt_macports.py
+++ b/upt_macports/upt_macports.py
@@ -139,9 +139,9 @@ class MacPortsPythonPackage(MacPortsPackage):
         return f'py-{name}'
 
     def _python_root_name(self):
-        pypi_name = self.upt_pkg.get_archive().filename.split('-'+self.upt_pkg.version)[0] # noqa
-        if pypi_name != self.upt_pkg.name.lower():
-            return pypi_name
+        """Return PyPI name if different than MacPorts naming convention."""
+        if self.upt_pkg.name != self.upt_pkg.name.lower():
+            return self.upt_pkg.name
 
     @staticmethod
     def _normalized_macports_folder(name):


### PR DESCRIPTION
The latest version of upt-pypi (v0.5.1) returns the proper capitalization of the PyPI package name. So there is no need anymore to reconstruct this ourselves from the archive filename.